### PR TITLE
Fixes link to Github repository.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
 
     <name>SwiftLint</name>
     <version>1.7</version>
-    <vendor email="alex@lonelybytes.com" url="http://github.com/SwiftLintAppCode">Alexander Babaev</vendor>
+    <vendor email="alex@lonelybytes.com" url="http://github.com/bealex/SwiftLintAppCode">Alexander Babaev</vendor>
 
     <description><![CDATA[
 <p>Provides highlighting of the SwiftLint errors. You can download it here: <a href="https://github.com/realm/SwiftLint">https://github.com/realm/SwiftLint</a>.


### PR DESCRIPTION
Currently, the link seen in AppCode's plugin manager is dead. This fixes that.