### PR TITLE
Moves config to Tools group; shorter label

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -44,6 +44,7 @@ To configure SwiftLint, create ".swiftlint.yml" file in the project root. See <h
                          level="WARNING"
                          enabledByDefault="true"/>
         <applicationConfigurable instance="com.lonelybytes.swiftlint.Configuration"
-                                 displayName="SwiftLint Configuration"/>
+                                 displayName="SwiftLint"
+                                 groupId="tools"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
SwiftLint is a tool, so I think its settings should be under Tools; this also avoids cluttering the top level of the settings dialogue.

Also, "Configuration" is redundant; we know that we are in the settings dialog! Hence, shortening that.