### PR TITLE
Handle symlinks in swiftlint path

### DIFF
--- a/src/com/lonelybytes/swiftlint/Configuration.java
+++ b/src/com/lonelybytes/swiftlint/Configuration.java
@@ -109,7 +109,11 @@ public class Configuration implements Configurable {
         if (appPath == null || appPath.isEmpty()) {
             File swiftLintFilePath = PathEnvironmentVariableUtil.findInPath("swiftlint");
             if (swiftLintFilePath != null) {
-                browser.getTextField().setText(swiftLintFilePath.getAbsolutePath());
+                try {
+                    browser.getTextField().setText(swiftLintFilePath.getCanonicalPath());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             } else {
                 browser.getTextField().setText(DEFAULT_SWIFTLINT_PATH);
             }


### PR DESCRIPTION
It would be nice if the configuration could handle symlinks.
I have change it to use getCanonicalPath instead of using getAbsolutePath.

Had some problems with actually test the changes, so please do a quick check :)

